### PR TITLE
Add style prefix function to support older Safari

### DIFF
--- a/src/overdrive.js
+++ b/src/overdrive.js
@@ -1,21 +1,9 @@
 import React from 'react'
 import ReactDOM  from 'react-dom'
+import prefix from './prefix'
 
 const renderSubtreeIntoContainer = ReactDOM.unstable_renderSubtreeIntoContainer;
 const components = {};
-
-const prefix = styles => {
-    const propertiesToPrefix = ['transform', 'transformOrigin', 'transition'];
-    const prefix = 'Webkit';
-    const prefixedStyles = {};
-    Object.keys(styles).forEach(property => {
-        if (propertiesToPrefix.indexOf(property) >= 0) {
-            prefixedStyles[prefix + property[0].toUpperCase() + property.slice(1)] = styles[property];
-        }
-        prefixedStyles[property] = styles[property];
-    });
-    return prefixedStyles;
-}
 
 class Overdrive extends React.Component {
 

--- a/src/overdrive.js
+++ b/src/overdrive.js
@@ -4,6 +4,19 @@ import ReactDOM  from 'react-dom'
 const renderSubtreeIntoContainer = ReactDOM.unstable_renderSubtreeIntoContainer;
 const components = {};
 
+const prefix = styles => {
+    const propertiesToPrefix = ['transform', 'transformOrigin', 'transition'];
+    const prefix = 'Webkit';
+    const prefixedStyles = {};
+    Object.keys(styles).forEach(property => {
+        if (propertiesToPrefix.indexOf(property) >= 0) {
+            prefixedStyles[prefix + property[0].toUpperCase() + property.slice(1)] = styles[property];
+        }
+        prefixedStyles[property] = styles[property];
+    });
+    return prefixedStyles;
+}
+
 class Overdrive extends React.Component {
 
     constructor(props) {
@@ -49,34 +62,34 @@ class Overdrive extends React.Component {
 
         const sourceEnd = React.cloneElement(prevElement, {
             key: '1',
-            style: {
+            style: prefix({
                 ...transition,
                 ...prevPosition,
                 margin: nextPosition.margin,
                 opacity: 0,
                 transform: `matrix(${1 / targetScaleX}, 0, 0, ${1 / targetScaleY}, ${-targetTranslateX}, ${-targetTranslateY})`
-            }
+            })
         });
 
         const targetStart = React.cloneElement(this.props.children, {
             key: '2',
-            style: {
+            style: prefix({
                 ...transition,
                 ...nextPosition,
                 margin: prevPosition.margin,
                 opacity: 0,
                 transform: `matrix(${targetScaleX}, 0, 0, ${targetScaleY}, ${targetTranslateX}, ${targetTranslateY})`
-            }
+            })
         });
 
         const targetEnd = React.cloneElement(this.props.children, {
             key: '2',
-            style: {
+            style: prefix({
                 ...transition,
                 ...nextPosition,
                 opacity: 1,
                 transform: noTransform
-            }
+            })
         });
 
         const start = <div>{sourceStart}{targetStart}</div>;

--- a/src/overdrive.js
+++ b/src/overdrive.js
@@ -40,12 +40,12 @@ class Overdrive extends React.Component {
 
         const sourceStart = React.cloneElement(prevElement, {
             key: '1',
-            style: {
+            style: prefix({
                 ...transition,
                 ...prevPosition,
                 opacity: 1,
                 transform: noTransform
-            }
+            })
         });
 
         const sourceEnd = React.cloneElement(prevElement, {

--- a/src/prefix.js
+++ b/src/prefix.js
@@ -1,6 +1,7 @@
+const propertiesToPrefix = ['transform', 'transformOrigin', 'transition'];
+const prefix = 'Webkit';
+
 const prefix = styles => {
-    const propertiesToPrefix = ['transform', 'transformOrigin', 'transition'];
-    const prefix = 'Webkit';
     const prefixedStyles = {};
     const styleProperties = Object.keys(styles);
     for (let i = 0; i < styleProperties.length; i++) {

--- a/src/prefix.js
+++ b/src/prefix.js
@@ -1,5 +1,5 @@
 const propertiesToPrefix = ['transform', 'transformOrigin', 'transition'];
-const prefix = 'Webkit';
+const webkitPrefix = 'Webkit';
 
 const prefix = styles => {
     const prefixedStyles = {};
@@ -8,7 +8,7 @@ const prefix = styles => {
         const property = styleProperties[i];
         for (let i = 0; i < propertiesToPrefix.length; i++) {
             if (propertiesToPrefix[i] === property) {
-                const prefixedProperty = prefix + property[0].toUpperCase() + property.slice(1);
+                const prefixedProperty = webkitPrefix + property[0].toUpperCase() + property.slice(1);
                 prefixedStyles[prefixedProperty] = styles[property];
             }
             prefixedStyles[property] = styles[property];

--- a/src/prefix.js
+++ b/src/prefix.js
@@ -1,0 +1,19 @@
+const prefix = styles => {
+    const propertiesToPrefix = ['transform', 'transformOrigin', 'transition'];
+    const prefix = 'Webkit';
+    const prefixedStyles = {};
+    const styleProperties = Object.keys(styles);
+    for (let i = 0; i < styleProperties.length; i++) {
+        const property = styleProperties[i];
+        for (let i = 0; i < propertiesToPrefix.length; i++) {
+            if (propertiesToPrefix[i] === property) {
+                const prefixedProperty = prefix + property[0].toUpperCase() + property.slice(1);
+                prefixedStyles[prefixedProperty] = styles[property];
+            }
+            prefixedStyles[property] = styles[property];
+        }
+    }
+    return prefixedStyles;
+};
+
+export default prefix;


### PR DESCRIPTION
Adds style support for older Safari that requires `-webkit-transition`, etc. Reference: #14