### PR TITLE
Add only children check and element props

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ const page = (props) => (
 | Prop           | Description                                                                                                                  | Default Value |
 |----------------|------------------------------------------------------------------------------------------------------------------------------|---------------|
 | id             | Required. A unique string to identify the component.                                                                         |               |
+| element             | Declare an element to render.                                                                         | div              |
 | duration       | Animation duration (in milliseconds).                                                                                         | 200           |
 | animationDelay | Add delay of calculating the mounted component position. Setting to `1` usually helps avoiding issues with window scrolling. | null          |
 

--- a/__tests__/overdrive.test.js
+++ b/__tests__/overdrive.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Overdrive from '../src/overdrive';
+import renderer from 'react-test-renderer';
+
+describe('Overdrive', () => {
+    it('should use props element to render', () => {
+        const component = renderer.create(
+            <Overdrive id="test" element="h1"><span>test</span></Overdrive>
+        );
+        let tree = component.toJSON();
+        expect(tree.type).toEqual('h1');
+    });
+});

--- a/demos/website/pages/index.js
+++ b/demos/website/pages/index.js
@@ -199,7 +199,7 @@ class page extends React.Component {
                                       prefetch
                                       href={`/character?id=${character.id}&name=${character.name}&image=${character.image}`}>
                                     <a>
-                                        <Overdrive id={character.id}
+                                        <Overdrive element="span" id={character.id}
                                                    style={{display: 'inline-block'}}>
                                             <img {...image}
                                                  src={`https://cdn.filestackcontent.com/${character.image}`}/>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jest": "^19.0.2",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-test-renderer": "^15.5.4",
     "webpack": "2.2.1",
     "yargs": "6.6.0"
   },

--- a/src/overdrive.js
+++ b/src/overdrive.js
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM  from 'react-dom'
 import prefix from './prefix'
 
+
 const renderSubtreeIntoContainer = ReactDOM.unstable_renderSubtreeIntoContainer;
 const components = {};
 
@@ -184,14 +185,15 @@ class Overdrive extends React.Component {
     }
 
     render() {
-        const {id, duration, animationDelay, style = {}, ...rest} = this.props;
+        const {id, duration, animationDelay, style = {}, children, ...rest} = this.props;
         const newStyle = {
             ...style,
             opacity: (this.state.loading ? 0 : 1)
         };
+        const onlyChild = React.Children.only(children);
         return (
             <div ref={c => (this.element = c && c.firstChild)} style={newStyle} {...rest}>
-                {this.props.children}
+                {onlyChild}
             </div>
         );
     }

--- a/src/overdrive.js
+++ b/src/overdrive.js
@@ -185,16 +185,21 @@ class Overdrive extends React.Component {
     }
 
     render() {
-        const {id, duration, animationDelay, style = {}, children, ...rest} = this.props;
+        const {id, duration, animationDelay, style = {}, children, element, ...rest} = this.props;
         const newStyle = {
             ...style,
             opacity: (this.state.loading ? 0 : 1)
         };
         const onlyChild = React.Children.only(children);
-        return (
-            <div ref={c => (this.element = c && c.firstChild)} style={newStyle} {...rest}>
-                {onlyChild}
-            </div>
+
+        return React.createElement(
+            element,
+            {
+                ref: c => (this.element = c && c.firstChild),
+                style: newStyle,
+                ...rest,
+            },
+            onlyChild
         );
     }
 }
@@ -202,10 +207,12 @@ class Overdrive extends React.Component {
 Overdrive.propTypes = {
     id: React.PropTypes.string.isRequired,
     duration: React.PropTypes.number,
+    element: React.PropTypes.string,
     animationDelay: React.PropTypes.number
 };
 
 Overdrive.defaultProps = {
+    element: 'div',
     duration: 200
 };
 


### PR DESCRIPTION
Hi @berzniz, nice component. I make a PR, the reason below:

## only children check

Because the component uses `firstChild`, there must be just one child.

## element props

The component wraps a div around children as default, there is a prop need to declare an element to wrap its children for HTML semantic.

Hope you can check this PR in your free time.