### PR TITLE
Simplify positioning using `position: fixed`

### DIFF
--- a/src/overdrive.js
+++ b/src/overdrive.js
@@ -20,8 +20,7 @@ class Overdrive extends React.Component {
     animate(prevPosition, prevElement) {
         const {duration} = this.props;
 
-        prevPosition.top += (window.pageYOffset || document.documentElement.scrollTop);
-        const nextPosition = this.getPosition(true);
+        const nextPosition = this.getPosition();
         const noTransform = 'scaleX(1) scaleY(1) translateX(0px) translateY(0px)';
         const targetScaleX = prevPosition.width / nextPosition.width;
         const targetScaleY = prevPosition.height / nextPosition.height;
@@ -168,21 +167,21 @@ class Overdrive extends React.Component {
         this.onShow();
     }
 
-    getPosition(addOffset) {
+    getPosition() {
         const node = this.element;
         const rect = node.getBoundingClientRect();
         const computedStyle = getComputedStyle(node);
         const marginTop = parseInt(computedStyle.marginTop, 10);
         const marginLeft = parseInt(computedStyle.marginLeft, 10);
         return {
-            top: (rect.top - marginTop) + ((addOffset ? 1 : 0) * (window.pageYOffset || document.documentElement.scrollTop)),
-            left: (rect.left - marginLeft),
+            top: rect.top - marginTop,
+            left: rect.left - marginLeft,
             width: rect.width,
             height: rect.height,
             margin: computedStyle.margin,
             padding: computedStyle.padding,
             borderRadius: computedStyle.borderRadius,
-            position: 'absolute'
+            position: 'fixed'
         };
     }
 


### PR DESCRIPTION
Thanks for providing this is a great way to add transitions between elements. Getting the exact position of a DOM node is tricky. In [this](http://javascript.info/coordinates) article all the quirks are documented. After experimenting a little bit with this library I noticed that in some cases `getPosition()` is not able to calculate the correct position. 

In the [summary](http://javascript.info/coordinates#summary) of the article previously mentioned the easiest way to get the correct positioning is to use window coordinates from `getBoundingClientRect` in combination with `position:fixed`. This simplifies the calculation a bit too. 

The demos you provided are working fine with this modifications. 