### PR TITLE
Update React peerDependency to support react@16.

### DIFF
--- a/demos/nextgram/package.json
+++ b/demos/nextgram/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "dependencies": {
     "next": "^2.1.1",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-overdrive": "^0.0.7"
   },
   "devDependencies": {

--- a/demos/nextjs/package.json
+++ b/demos/nextjs/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "glamor": "^2.20.24",
     "next": "^2.0.0",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-overdrive": "^0.0.7"
   }
 }

--- a/demos/react-router-v4/package.json
+++ b/demos/react-router-v4/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-overdrive": "^0.0.7",
     "react-router-dom": "^4.0.0"
   },

--- a/demos/website/package.json
+++ b/demos/website/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "glamor": "^2.20.24",
     "next": "^2.0.0",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-overdrive": "^0.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "babel": "6.5.2",
     "babel-core": "6.22.1",
-    "babel-jest": "^19.0.0",
+    "babel-jest": "^21.2.0",
     "babel-loader": "6.2.10",
     "babel-plugin-add-module-exports": "0.1.2",
     "babel-plugin-transform-class-properties": "^6.19.0",
@@ -32,11 +32,11 @@
     "babel-preset-es2017": "^6.16.0",
     "babel-preset-react": "6.x.x",
     "babel-runtime": "^6.23.0",
-    "jest": "^19.0.2",
+    "jest": "^21.2.1",
     "prop-types": "^15.5.10",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-test-renderer": "^15.5.4",
+    "react-test-renderer": "^16.0.0",
     "webpack": "2.2.1",
     "yargs": "6.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0"
+    "react": "^15.5.0 || ^16.0.0",
+    "react-dom": "^15.5.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "babel-runtime": "^6.23.0",
     "jest": "^19.0.2",
     "prop-types": "^15.5.10",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-test-renderer": "^15.5.4",
     "webpack": "2.2.1",
     "yargs": "6.6.0"


### PR DESCRIPTION
I tested react-overdrive with the newly released React 16 and it works without modifications. This pull request updates the peer dependency to support React 16 without npm warnings.