### PR TITLE
Fix type definitions for TS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ $ npm install react-overdrive --save
 
 ## Usage
 
+**Note:** If you're using TypeScript, you will need to `npm install -D @types/react`.
+
 ### Example with routing
 
 Wrap any element (not just images) in a `<Overdrive id=""></Overdrive>` component. Add the same `id` to create a transition between the elements.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 
 declare module 'react-overdrive' {
   export interface Props {
-    id: string | number
+    id: string
     duration?: number
     easing?: string
     element?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,17 @@
+///<reference types="react" />
+
 declare module 'react-overdrive' {
-  import {Component, CSSProperties} from 'react'
   export interface Props {
-    id: string
+    id: string | number
     duration?: number
     easing?: string
     element?: string
     animationDelay?: number
     onAnimationEnd?: () => void
-    style?: CSSProperties
+    style?: React.CSSProperties
   }
   export interface State {
     loading: boolean
   }
-  export default class Overdrive extends Component<Props, State> {}
+  export default class Overdrive extends React.Component<Props, State> { }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "test": "jest",
     "standard": "standard"
   },
-  "dependencies": {
-    "@types/react": "^15.5.0 || ^16.0.0"
-  },
   "peerDependencies": {
     "react": "^15.5.0 || ^16.0.0",
     "react-dom": "^15.5.0 || ^16.0.0"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,21 @@
 {
   "name": "react-overdrive",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Super easy magic-move transitions for React apps",
   "main": "lib/Overdrive.min.js",
   "files": [
     "lib",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "standard && npm test && NODE_ENV=production webpack --env build",
     "dev": "webpack --progress --colors --watch --env dev",
     "test": "jest",
     "standard": "standard"
+  },
+  "dependencies": {
+    "@types/react": "^15.5.0 || ^16.0.0"
   },
   "peerDependencies": {
     "react": "^15.5.0 || ^16.0.0",
@@ -46,6 +50,7 @@
     "type": "git",
     "url": "https://github.com/berzniz/react-overdrive.git"
   },
+  "types": "./index.d.ts",
   "keywords": [
     "magic-move",
     "animations",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,12 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/react@^15.5.0 || ^16.0.0":
+  version "16.4.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.3.tgz#c7009925dd9a7a2e1c2ef05c653f37005706dec8"
+  dependencies:
+    csstype "^2.2.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1437,6 +1443,10 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.5.tgz#4125484a3d42189a863943f23b9e4b80fedfa106"
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
- A reference to react types was added to the definition file.
- The react import was removed as React doesn't use module declaration. It uses namespace.
- Adjusted CSSProperties and Component types to use React namespace.
- Added index.d.ts file to final package (was missing from files array).
- Version bump.